### PR TITLE
Printing complete path of downloaded report in console

### DIFF
--- a/Samples/Payments/CoreServices/CapturePayment.rb
+++ b/Samples/Payments/CoreServices/CapturePayment.rb
@@ -37,5 +37,7 @@ class CapturePayment
   rescue StandardError => err
     puts err.message
   end
-  CapturePayment.new.main
+  if __FILE__ == $0
+    CapturePayment.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/ProcessAuthorizationReversal.rb
+++ b/Samples/Payments/CoreServices/ProcessAuthorizationReversal.rb
@@ -38,5 +38,7 @@ class AuthReversal
   rescue StandardError => err
     puts err.message
   end
-  AuthReversal.new.main
+  if __FILE__ == $0
+    AuthReversal.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/ProcessCredit.rb
+++ b/Samples/Payments/CoreServices/ProcessCredit.rb
@@ -51,5 +51,7 @@ class CreateCredit
   rescue StandardError => err
     puts err.message
   end
-  CreateCredit.new.main
+  if __FILE__ == $0
+    CreateCredit.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/ProcessPayment.rb
+++ b/Samples/Payments/CoreServices/ProcessPayment.rb
@@ -77,5 +77,7 @@ class CreatePayment
   rescue StandardError => err
     puts err.message
   end
-  CreatePayment.new.main(false)
+  if __FILE__ == $0
+    CreatePayment.new.main(false)
+  end
 end

--- a/Samples/Payments/CoreServices/RefundCapture.rb
+++ b/Samples/Payments/CoreServices/RefundCapture.rb
@@ -33,5 +33,7 @@ class RefundCapture
   rescue StandardError => err
     puts err.message
   end
-  RefundCapture.new.main
+  if __FILE__ == $0
+    RefundCapture.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/RefundPayment.rb
+++ b/Samples/Payments/CoreServices/RefundPayment.rb
@@ -36,5 +36,7 @@ class RefundPayment
   rescue StandardError => err
     puts err.message
   end
-  RefundPayment.new.main
+  if __FILE__ == $0
+    RefundPayment.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/VoidCapture.rb
+++ b/Samples/Payments/CoreServices/VoidCapture.rb
@@ -27,5 +27,7 @@ class VoidCapture
   rescue StandardError => err
     puts err.message
   end
-  VoidCapture.new.main
+  if __FILE__ == $0
+    VoidCapture.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/VoidCredit.rb
+++ b/Samples/Payments/CoreServices/VoidCredit.rb
@@ -28,5 +28,7 @@ class VoidCredit
   rescue StandardError => err
     puts err.message
   end
-  VoidCredit.new.main
+  if __FILE__ == $0
+    VoidCredit.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/VoidPayment.rb
+++ b/Samples/Payments/CoreServices/VoidPayment.rb
@@ -29,5 +29,7 @@ class VoidPayment
   rescue StandardError => err
     puts err.message
   end
-  VoidPayment.new.main
+  if __FILE__ == $0
+    VoidPayment.new.main
+  end
 end

--- a/Samples/Payments/CoreServices/VoidRefund.rb
+++ b/Samples/Payments/CoreServices/VoidRefund.rb
@@ -29,5 +29,7 @@ class VoidRefund
   rescue StandardError => err
     puts err.message
   end
-  VoidRefund.new.main
+  if __FILE__ == $0
+    VoidRefund.new.main
+  end
 end

--- a/Samples/Reporting/CoreServices/CreateReportSubscriptionForReportNameByOrganization.rb
+++ b/Samples/Reporting/CoreServices/CreateReportSubscriptionForReportNameByOrganization.rb
@@ -15,16 +15,21 @@ class CreateReportSubscriptionForReportNameByOrganization
             "Request.MerchantID"
     ]
     request.report_mime_type="application/xml"
-    request.report_name = "TRR1_182"
+    request.report_name = "report_test_v1_subscription"
     request.report_frequency="WEEKLY"
     request.timezone="America/Chicago"
-    request.start_time="0900"
+    request.start_time="0902"
     request.start_day=1
     data, status_code, headers = api_instance.create_subscription(request)
     puts data, status_code, headers
-
+    if(status_code == 201)
+      require_relative './DeleteSubscriptionOfReportNameByOrganization.rb'
+      data, status_code, headers = api_instance.delete_subscription(request.report_name)
+    end
   rescue StandardError => err
     puts err.message
   end
-CreateReportSubscriptionForReportNameByOrganization.new.main
+  if __FILE__ == $0
+    CreateReportSubscriptionForReportNameByOrganization.new.main
+  end
 end

--- a/Samples/Reporting/CoreServices/DeleteSubscriptionOfReportNameByOrganization.rb
+++ b/Samples/Reporting/CoreServices/DeleteSubscriptionOfReportNameByOrganization.rb
@@ -3,9 +3,11 @@ require_relative '../../../Data/Configuration.rb'
 
 public
 class DeleteSubscriptionOfReportNameByOrganization
-  def main()
+  def main(report_name)
     config = MerchantConfiguration.new.merchantConfigProp()
-    report_name = "testrest_subcription_v1"
+    if report_name == nil
+      report_name = "testrest_subcription_v1"
+    end
     api_client = CyberSource::ApiClient.new
     api_instance = CyberSource::ReportSubscriptionsApi.new(api_client, config)
     data, status_code, headers = api_instance.delete_subscription(report_name)
@@ -13,7 +15,9 @@ class DeleteSubscriptionOfReportNameByOrganization
   rescue StandardError => err
     puts err.message
   end
-  DeleteSubscriptionOfReportNameByOrganization.new.main()
+  if __FILE__ == $0
+    DeleteSubscriptionOfReportNameByOrganization.new.main("testrest_subcription_v1")
+  end
 end
 
 

--- a/Samples/Reporting/CoreServices/DownloadReport.rb
+++ b/Samples/Reporting/CoreServices/DownloadReport.rb
@@ -5,6 +5,7 @@ require 'csv'
 public
 class DownloadReport
   def main()
+    file_path = "..\\cybersource-rest-samples-ruby\\resource\\report_download.csv"
     config = MerchantConfiguration.new.merchantConfigProp()
     reportDate = "2018-09-02"
     reportName = "testrest_v2"
@@ -16,12 +17,12 @@ class DownloadReport
     data, status_code, headers = api_instance.download_report(reportDate, reportName, opts)
     puts data, status_code, headers
     # Writing Response to CSV file
-    CSV.open("..\\cybersource-rest-samples-ruby\\resource\\report_download.csv","a+") do |writeToCSV|
+    CSV.open(file_path,"a+") do |writeToCSV|
       if data != nil
         writeToCSV << [ data.to_s ]
       end
     end
-
+    puts "File downloaded at the below location:\n" + File.expand_path(file_path)
   rescue StandardError => err
     puts err.message
     puts err.backtrace

--- a/Samples/SecureFileShare/CoreServices/DownloadFileWithFileIdentifier.rb
+++ b/Samples/SecureFileShare/CoreServices/DownloadFileWithFileIdentifier.rb
@@ -5,6 +5,7 @@ require_relative '../../../Data/Configuration.rb'
 public
 class DownloadFileWithFileIdentifier
   def main()
+    file_path = "..\\cybersource-rest-samples-ruby\\resource\\report_download_file_with_file_identifier.csv"
     config = MerchantConfiguration.new.merchantConfigProp()
     file_id = "RGVtb19SZXBvcnQtNzg1NWQxM2YtOTM5Ny01MTEzLWUwNTMtYTI1ODhlMGE3MTkyLnhtbC0yMDE4LTEwLTIw"
     api_client = CyberSource::ApiClient.new
@@ -13,14 +14,14 @@ class DownloadFileWithFileIdentifier
     opts[:'organization_id'] = "testrest"
     data, status_code, headers = api_instance.get_file(file_id, opts)
     puts data, status_code, headers
-
+ 
     # Writing Response to CSV file
-    CSV.open("..\\cybersource-rest-samples-ruby\\resource\\report_download_file_with_file_identifier.csv","a+") do |writeToCSV|
+    CSV.open(file_path,"a+") do |writeToCSV|
       if data != nil
         writeToCSV << [ data.to_s ]
       end
     end
-
+    puts "File downloaded at the below location:\n" + File.expand_path(file_path)
   rescue StandardError => err
     puts err.message
   end

--- a/Samples/TMS/CoreServices/CreateInstrumentIdentifier.rb
+++ b/Samples/TMS/CoreServices/CreateInstrumentIdentifier.rb
@@ -42,5 +42,7 @@ class CreateInstrumentIdentifier
   rescue StandardError => err
     puts err.message
   end
-  CreateInstrumentIdentifier.new.main
+  if __FILE__ == $0
+    CreateInstrumentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/CreatePaymentInstrument.rb
+++ b/Samples/TMS/CoreServices/CreatePaymentInstrument.rb
@@ -48,5 +48,7 @@ class CreatePaymentIdentifier
     rescue StandardError => err
       puts err.message
     end
-    CreatePaymentIdentifier.new.main
+    if __FILE__ == $0
+      CreatePaymentIdentifier.new.main
+    end
 end

--- a/Samples/TMS/CoreServices/DeleteInstrumentIdentifier.rb
+++ b/Samples/TMS/CoreServices/DeleteInstrumentIdentifier.rb
@@ -25,5 +25,7 @@ class RemoveInstrumentIdentifier
     puts err.message
     puts err.backtrace
   end
-  RemoveInstrumentIdentifier.new.main
+  if __FILE__ == $0
+    RemoveInstrumentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/DeletePaymentInstrument.rb
+++ b/Samples/TMS/CoreServices/DeletePaymentInstrument.rb
@@ -25,5 +25,7 @@ class RemovePaymentIdentifier
     puts err.message
     puts err.backtrace
   end
-  RemovePaymentIdentifier.new.main
+  if __FILE__ == $0
+    RemovePaymentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/RetrieveAllPaymentInstruments.rb
+++ b/Samples/TMS/CoreServices/RetrieveAllPaymentInstruments.rb
@@ -25,5 +25,7 @@ class RetrieveAllPaymentIdentifierFromInstrument
     puts err.message
     puts err.backtrace
   end
-  RetrieveAllPaymentIdentifierFromInstrument.new.main
+  if __FILE__ == $0
+    RetrieveAllPaymentIdentifierFromInstrument.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/RetrieveInstrumentIdentifier.rb
+++ b/Samples/TMS/CoreServices/RetrieveInstrumentIdentifier.rb
@@ -26,5 +26,7 @@ class RetrieveInstrumentIdentifier
     puts err.message
     puts err.backtrace
   end
-  RetrieveInstrumentIdentifier.new.main
+  if __FILE__ == $0
+    RetrieveInstrumentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/RetrievePaymentInstrument.rb
+++ b/Samples/TMS/CoreServices/RetrievePaymentInstrument.rb
@@ -26,5 +26,7 @@ class PaymentInstrumentIdentifier
     puts err.message
     puts err.backtrace
   end
-  PaymentInstrumentIdentifier.new.main
+  if __FILE__ == $0
+    PaymentInstrumentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/UpdateInstrumentIdentifier.rb
+++ b/Samples/TMS/CoreServices/UpdateInstrumentIdentifier.rb
@@ -41,5 +41,7 @@ class UpdateInstrumentIdentifier
   rescue StandardError => err
     puts err.message
   end
-  UpdateInstrumentIdentifier.new.main
+  if __FILE__ == $0
+    UpdateInstrumentIdentifier.new.main
+  end
 end

--- a/Samples/TMS/CoreServices/UpdatePaymentInstrument.rb
+++ b/Samples/TMS/CoreServices/UpdatePaymentInstrument.rb
@@ -52,5 +52,7 @@ class UpdatePaymentIdentifier
   rescue StandardError => err
     puts err.message
   end
-  UpdatePaymentIdentifier.new.main
+  if __FILE__ == $0
+    UpdatePaymentIdentifier.new.main
+  end
 end


### PR DESCRIPTION
1. Printing complete path of downloaded report in console
2. Fix for dynamic call sample codes where the response was getting printed multiple times in the console